### PR TITLE
enable ZMK Studio support for Fine!40

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -15,3 +15,5 @@
 include:
   - board: nice_nano_v2
     shield: fine40
+    snippet: studio-rpc-usb-uart
+    cmake-args: -DCONFIG_ZMK_STUDIO=y

--- a/config/boards/shields/fine40/fine40.overlay
+++ b/config/boards/shields/fine40/fine40.overlay
@@ -1,13 +1,14 @@
 #include <dt-bindings/zmk/matrix_transform.h>
+#include <physical_layouts.dtsi>
 
 / {
     chosen {
         zmk,kscan = &kscan0;
-		zmk,matrix-transform = &default_transform;
-		zephyr,display = &oled;
+        zmk,physical-layout = &fine40_layout0;
+        zephyr,display = &oled;
     };
 
-	default_transform: keymap_transform_0 {
+default_transform: keymap_transform_0 {
 		compatible = "zmk,matrix-transform";
 		columns = <6>;
 		rows = <8>;
@@ -44,8 +45,70 @@
 			, <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };
-	
-		encoder: encoder {
+
+    fine40_layout0: fine40_layout_0 {
+        compatible = "zmk,physical-layout";
+        display-name = "fine!40";
+
+        transform = <&default_transform>;
+        kscan = <&kscan0>;
+
+        keys
+            = <&key_physical_attrs 100 100    0    0   0    0   0>
+            , <&key_physical_attrs 100 100  100    0   0    0   0>
+            , <&key_physical_attrs 100 100  200    0   0    0   0>
+            , <&key_physical_attrs 100 100  300    0   0    0   0>
+            , <&key_physical_attrs 100 100  400    0   0    0   0>
+            , <&key_physical_attrs 100 100  500    0   0    0   0>
+            , <&key_physical_attrs 100 100  600    0   0    0   0>
+            , <&key_physical_attrs 100 100  700    0   0    0   0>
+            , <&key_physical_attrs 100 100  800    0   0    0   0>
+            , <&key_physical_attrs 100 100  900    0   0    0   0>
+            , <&key_physical_attrs 100 100 1000    0   0    0   0>
+            , <&key_physical_attrs 100 100 1100    0   0    0   0>
+
+            , <&key_physical_attrs 100 100    0  100   0    0   0>
+            , <&key_physical_attrs 100 100  100  100   0    0   0>
+            , <&key_physical_attrs 100 100  200  100   0    0   0>
+            , <&key_physical_attrs 100 100  300  100   0    0   0>
+            , <&key_physical_attrs 100 100  400  100   0    0   0>
+            , <&key_physical_attrs 100 100  500  100   0    0   0>
+            , <&key_physical_attrs 100 100  600  100   0    0   0>
+            , <&key_physical_attrs 100 100  700  100   0    0   0>
+            , <&key_physical_attrs 100 100  800  100   0    0   0>
+            , <&key_physical_attrs 100 100  900  100   0    0   0>
+            , <&key_physical_attrs 100 100 1000  100   0    0   0>
+            , <&key_physical_attrs 100 100 1100  100   0    0   0>
+
+            , <&key_physical_attrs 100 100    0  200   0    0   0>
+            , <&key_physical_attrs 100 100  100  200   0    0   0>
+            , <&key_physical_attrs 100 100  200  200   0    0   0>
+            , <&key_physical_attrs 100 100  300  200   0    0   0>
+            , <&key_physical_attrs 100 100  400  200   0    0   0>
+            , <&key_physical_attrs 100 100  500  200   0    0   0>
+            , <&key_physical_attrs 100 100  600  200   0    0   0>
+            , <&key_physical_attrs 100 100  700  200   0    0   0>
+            , <&key_physical_attrs 100 100  800  200   0    0   0>
+            , <&key_physical_attrs 100 100  900  200   0    0   0>
+            , <&key_physical_attrs 100 100 1000  200   0    0   0>
+            , <&key_physical_attrs 100 100 1100  200   0    0   0>
+
+            , <&key_physical_attrs 100 100    0  300   0    0   0>
+            , <&key_physical_attrs 100 100  100  300   0    0   0>
+            , <&key_physical_attrs 100 100  200  300   0    0   0>
+            , <&key_physical_attrs 100 100  300  300   0    0   0>
+            , <&key_physical_attrs 100 100  400  300   0    0   0>
+            , <&key_physical_attrs 100 100  500  300   0    0   0>
+            , <&key_physical_attrs 100 100  600  300   0    0   0>
+            , <&key_physical_attrs 100 100  700  300   0    0   0>
+            , <&key_physical_attrs 100 100  800  300   0    0   0>
+            , <&key_physical_attrs 100 100  900  300   0    0   0>
+            , <&key_physical_attrs 100 100 1000  300   0    0   0>
+            , <&key_physical_attrs 100 100 1100  300   0    0   0>
+            ;
+    };
+
+	encoder: encoder {
 		compatible = "alps,ec11";
 		label = "ENCODER";
 		a-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
@@ -59,6 +122,7 @@
 		sensors = <&encoder>;
 	};
 	
+
 };
 
 &pro_micro_i2c {

--- a/config/boards/shields/fine40/fine40.zmk.yml
+++ b/config/boards/shields/fine40/fine40.zmk.yml
@@ -9,3 +9,4 @@ features:
   - keys
   - display
   - encoder
+  - studio

--- a/config/fine40.keymap
+++ b/config/fine40.keymap
@@ -47,7 +47,7 @@
 				&sys_reset &bootloader &bt BT_CLR &bt BT_PRV &bt BT_NXT &trans  &trans  &trans  &trans  &trans  &trans  &trans
 				&trans     &kp F11     &kp F12    &kp F13    &kp F14    &kp F15 &kp F16 &kp F17 &kp F18 &kp F19 &kp F20 &trans
 				&trans     &kp F1      &kp F2     &kp F3     &kp F4     &kp F5  &kp F6  &kp F7  &kp F8  &kp F9  &kp F10 &trans
-				&trans     &trans      &trans     &trans     &trans     &trans  &trans  &trans  &trans  &trans  &trans  &ext_power EP_ON
+				&studio_unlock     &trans      &trans     &trans     &trans     &trans  &trans  &trans  &trans  &trans  &trans  &ext_power EP_ON
 			>;
 		};
 	};


### PR DESCRIPTION
- Added physical layout with keys property
- Switched chosen to zmk,physical-layout instead of zmk,matrix-transform
- Updated build.yaml with studio-rpc-usb-uart and CONFIG_ZMK_STUDIO=y
- Bound &studio_unlock to Left Control on the control layer