### PR TITLE
Pinned to ZMK v0.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,4 +2,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3

--- a/config/west.yml
+++ b/config/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: v0.3
       import: app/west.yml
   self:
     path: config


### PR DESCRIPTION
We can no longer track ZMK @main due to breaking changes in v0.4. This was causing the github build action to break. Official documentation recommends pinning the ZMK version for casual users. Users tracking @main are now considered "testers".

Maybe someday I'll go through and update to be compatible with the new HWMv2 but for now, pinning the versioning is the quickest fix.

Read more here:
https://zmk.dev/blog/2025/12/09/zephyr-4-1
https://zmk.dev/blog/2025/06/20/pinned-zmk